### PR TITLE
Issue 80: TextContent extension for GFM tables

### DIFF
--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/HtmlTablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/HtmlTablesExtension.java
@@ -2,7 +2,7 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.internal.TableBlockParser;
-import org.commonmark.ext.gfm.tables.internal.TableNodeRenderer;
+import org.commonmark.ext.gfm.tables.internal.HtmlTableNodeRenderer;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.renderer.html.HtmlNodeRendererContext;
 import org.commonmark.renderer.html.HtmlNodeRendererFactory;
@@ -20,13 +20,13 @@ import org.commonmark.renderer.NodeRenderer;
  * The parsed tables are turned into {@link TableBlock} blocks.
  * </p>
  */
-public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
+public class HtmlTablesExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
 
-    private TablesExtension() {
+    private HtmlTablesExtension() {
     }
 
     public static Extension create() {
-        return new TablesExtension();
+        return new HtmlTablesExtension();
     }
 
     @Override
@@ -39,7 +39,7 @@ public class TablesExtension implements Parser.ParserExtension, HtmlRenderer.Htm
         rendererBuilder.nodeRendererFactory(new HtmlNodeRendererFactory() {
             @Override
             public NodeRenderer create(HtmlNodeRendererContext context) {
-                return new TableNodeRenderer(context);
+                return new HtmlTableNodeRenderer(context);
             }
         });
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TextContentTablesExtension.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/TextContentTablesExtension.java
@@ -1,0 +1,46 @@
+package org.commonmark.ext.gfm.tables;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.internal.TableBlockParser;
+import org.commonmark.ext.gfm.tables.internal.TextContentTableNodeRenderer;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.text.TextContentNodeRendererContext;
+import org.commonmark.renderer.text.TextContentNodeRendererFactory;
+import org.commonmark.renderer.text.TextContentRenderer;
+
+/**
+ * Extension for GFM tables using "|" pipes (GitHub Flavored Markdown).
+ * <p>
+ * Create it with {@link #create()} and then configure it on the builders
+ * ({@link org.commonmark.parser.Parser.Builder#extensions(Iterable)},
+ * {@link TextContentRenderer.Builder#extensions(Iterable)}).
+ * </p>
+ * <p>
+ * The parsed tables are turned into {@link TableBlock} blocks.
+ * </p>
+ */
+public class TextContentTablesExtension implements Parser.ParserExtension, TextContentRenderer.TextContentRendererExtension {
+
+    private TextContentTablesExtension() {
+    }
+
+    public static Extension create() {
+        return new TextContentTablesExtension();
+    }
+
+    @Override
+    public void extend(Parser.Builder parserBuilder) {
+        parserBuilder.customBlockParserFactory(new TableBlockParser.Factory());
+    }
+
+    @Override
+    public void extend(TextContentRenderer.Builder rendererBuilder) {
+        rendererBuilder.nodeRendererFactory(new TextContentNodeRendererFactory() {
+            @Override
+            public NodeRenderer create(TextContentNodeRendererContext context) {
+                return new TextContentTableNodeRenderer(context);
+            }
+        });
+    }
+}

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/HtmlTableNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/HtmlTableNodeRenderer.java
@@ -8,12 +8,12 @@ import org.commonmark.renderer.html.HtmlWriter;
 
 import java.util.*;
 
-public class TableNodeRenderer implements NodeRenderer {
+public class HtmlTableNodeRenderer implements NodeRenderer {
 
     private final HtmlWriter htmlWriter;
     private final HtmlNodeRendererContext context;
 
-    public TableNodeRenderer(HtmlNodeRendererContext context) {
+    public HtmlTableNodeRenderer(HtmlNodeRendererContext context) {
         this.htmlWriter = context.getWriter();
         this.context = context;
     }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TextContentTableNodeRenderer.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TextContentTableNodeRenderer.java
@@ -1,0 +1,104 @@
+package org.commonmark.ext.gfm.tables.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.commonmark.ext.gfm.tables.TableBlock;
+import org.commonmark.ext.gfm.tables.TableBody;
+import org.commonmark.ext.gfm.tables.TableCell;
+import org.commonmark.ext.gfm.tables.TableHead;
+import org.commonmark.ext.gfm.tables.TableRow;
+import org.commonmark.node.Node;
+import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.text.TextContentNodeRendererContext;
+import org.commonmark.renderer.text.TextContentWriter;
+
+/**
+ * The Table node renderer that is needed for rendering GFM tables (GitHub Flavored Markdown) to text.
+ */
+public class TextContentTableNodeRenderer implements NodeRenderer {
+
+    private final TextContentWriter textContentWriter;
+    private final TextContentNodeRendererContext context;
+
+    public TextContentTableNodeRenderer(TextContentNodeRendererContext context) {
+        this.textContentWriter = context.getWriter();
+        this.context = context;
+    }
+
+    @Override
+    public Set<Class<? extends Node>> getNodeTypes() {
+        return new HashSet<>(Arrays.asList(
+            TableBlock.class,
+            TableHead.class,
+            TableBody.class,
+            TableRow.class,
+            TableCell.class
+        ));
+    }
+
+    @Override
+    public void render(Node node) {
+        // We don't render the table header (node instanceof TableHead) and its children for the text content.
+
+        if (node instanceof TableBlock) {
+            renderBlock((TableBlock) node);
+        } else if (node instanceof TableHead) {
+            renderHead((TableHead) node);
+        } else if (node instanceof TableBody) {
+            renderBody((TableBody) node);
+        } else if (node instanceof TableRow) {
+            renderRow((TableRow) node);
+        } else if (node instanceof TableCell) {
+            renderCell((TableCell) node);
+        }
+    }
+
+    private void renderBlock(TableBlock tableBlock) {
+        renderChildren(tableBlock);
+        if (tableBlock.getNext() != null) {
+            textContentWriter.write("\n");
+        }
+    }
+
+    private void renderHead(TableHead tableHead) {
+        renderChildren(tableHead);
+    }
+
+    private void renderBody(TableBody tableBody) {
+        renderChildren(tableBody);
+    }
+
+    private void renderRow(TableRow tableRow) {
+        textContentWriter.line();
+        renderChildren(tableRow);
+        textContentWriter.line();
+    }
+
+    private void renderCell(TableCell tableCell) {
+        renderChildren(tableCell);
+        textContentWriter.colon();
+        textContentWriter.whitespace();
+    }
+
+    private void renderLastCell(TableCell tableCell) {
+        renderChildren(tableCell);
+    }
+
+    private void renderChildren(Node parent) {
+        Node node = parent.getFirstChild();
+        while (node != null) {
+            Node next = node.getNext();
+
+            // For last cell in row, we dont render the delimiter.
+            if (node instanceof TableCell && next == null) {
+                renderLastCell((TableCell) node);
+            } else {
+                context.render(node);
+            }
+
+            node = next;
+        }
+    }
+}

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/HtmlTablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/HtmlTablesTest.java
@@ -17,9 +17,9 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class TablesTest extends RenderingTestCase {
+public class HtmlTablesTest extends RenderingTestCase {
 
-    private static final Set<Extension> EXTENSIONS = Collections.singleton(TablesExtension.create());
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(HtmlTablesExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).build();
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TextContentTablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TextContentTablesTest.java
@@ -1,0 +1,179 @@
+package org.commonmark.ext.gfm.tables;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.commonmark.Extension;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.AttributeProvider;
+import org.commonmark.renderer.html.AttributeProviderContext;
+import org.commonmark.renderer.html.AttributeProviderFactory;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.renderer.text.TextContentNodeRendererFactory;
+import org.commonmark.renderer.text.TextContentRenderer;
+import org.commonmark.test.RenderingTestCase;
+import org.junit.Test;
+
+public class TextContentTablesTest extends RenderingTestCase {
+
+    private static final Set<Extension> EXTENSIONS = Collections.singleton(TextContentTablesExtension.create());
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    private static final TextContentRenderer RENDERER = TextContentRenderer.builder().extensions(EXTENSIONS).build();
+
+    @Test
+    public void mustHaveHeaderAndSeparator() {
+        assertRendering("Abc|Def", "Abc|Def");
+        assertRendering("Abc | Def", "Abc | Def");
+    }
+
+    @Test
+    public void separatorMustBeThreeOrMore() {
+        assertRendering("Abc|Def\n-|-", "Abc|Def\n-|-");
+        assertRendering("Abc|Def\n--|--", "Abc|Def\n--|--");
+    }
+
+    @Test
+    public void separatorCanNotHaveLeadingSpaceThenPipe() {
+        assertRendering("Abc|Def\n |---|---", "Abc|Def\n|---|---");
+    }
+
+    @Test
+    public void headerMustBeOneLine() {
+        assertRendering("No\nAbc|Def\n---|---", "No\nAbc|Def\n---|---");
+    }
+
+    @Test
+    public void oneHeadNoBody() {
+        assertRendering("Abc|Def\n---|---", "Abc: Def\n");
+    }
+
+    @Test
+    public void oneColumnOneHeadNoBody() {
+        String expected = "Abc\n";
+        assertRendering("|Abc\n|---\n", expected);
+        assertRendering("|Abc|\n|---|\n", expected);
+        assertRendering("Abc|\n---|\n", expected);
+
+        // Pipe required on separator
+        assertRendering("|Abc\n---\n", "|Abc");
+        // Pipe required on head
+        assertRendering("Abc\n|---\n", "Abc\n|---");
+    }
+
+    @Test
+    public void oneColumnOneHeadOneBody() {
+        String expected = "Abc\n1\n";
+        assertRendering("|Abc\n|---\n|1", expected);
+        assertRendering("|Abc|\n|---|\n|1|", expected);
+        assertRendering("Abc|\n---|\n1|", expected);
+
+        // Pipe required on separator
+        assertRendering("|Abc\n---\n|1", "|Abc\n|1");
+
+        // Pipe required on body
+        assertRendering("|Abc\n|---\n1\n", "Abc\n\n1");
+    }
+
+    @Test
+    public void oneHeadOneBody() {
+        assertRendering("Abc|Def\n---|---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void separatorMustNotHaveLessPartsThanHead() {
+        assertRendering("Abc|Def|Ghi\n---|---\n1|2|3", "Abc|Def|Ghi\n---|---\n1|2|3");
+    }
+
+    @Test
+    public void padding() {
+        assertRendering(" Abc  | Def \n --- | --- \n 1 | 2 ", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void paddingWithCodeBlockIndentation() {
+        assertRendering("Abc|Def\n---|---\n    1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void pipesOnOutside() {
+        assertRendering("|Abc|Def|\n|---|---|\n|1|2|", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void inlineElements() {
+        assertRendering("*Abc*|Def\n---|---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void escapedPipe() {
+        assertRendering("Abc|Def\n---|---\n1\\|2|20", "Abc: Def\n1|2: 20\n");
+    }
+
+    @Test
+    public void escapedBackslash() {
+        assertRendering("Abc|Def\n---|---\n1\\\\|2", "Abc: Def\n1\\: 2\n");
+    }
+
+    @Test
+    public void alignLeft() {
+        assertRendering("Abc|Def\n:---|---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void alignRight() {
+        assertRendering("Abc|Def\n---:|---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void alignCenter() {
+        assertRendering("Abc|Def\n:---:|---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void alignCenterSecond() {
+        assertRendering("Abc|Def\n---|:---:\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void alignLeftWithSpaces() {
+        assertRendering("Abc|Def\n :--- |---\n1|2", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void alignmentMarkerMustBeNextToDashes() {
+        assertRendering("Abc|Def\n: ---|---", "Abc|Def\n: ---|---");
+        assertRendering("Abc|Def\n--- :|---", "Abc|Def\n--- :|---");
+        assertRendering("Abc|Def\n---|: ---", "Abc|Def\n---|: ---");
+        assertRendering("Abc|Def\n---|--- :", "Abc|Def\n---|--- :");
+    }
+
+    @Test
+    public void bodyCanNotHaveMoreColumnsThanHead() {
+        assertRendering("Abc|Def\n---|---\n1|2|3", "Abc: Def\n1: 2\n");
+    }
+
+    @Test
+    public void bodyWithFewerColumnsThanHeadResultsInEmptyCells() {
+        assertRendering("Abc|Def|Ghi\n---|---|---\n1|2", "Abc: Def: Ghi\n1: 2: \n");
+    }
+
+    @Test
+    public void insideBlockQuote() {
+        assertRendering("> Abc|Def\n> ---|---\n> 1|2", "«\nAbc: Def\n1: 2\n»");
+    }
+
+    @Test
+    public void tableEndWithoutEmptyLine() {
+        assertRendering("Abc|Def\n---|---\n1|2\ntable, you are over", "Abc: Def\n1: 2\n\ntable, you are over");
+    }
+
+    @Override
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+}

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -4,7 +4,7 @@ import org.commonmark.Extension;
 import org.commonmark.ext.autolink.AutolinkExtension;
 import org.commonmark.ext.ins.InsExtension;
 import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
-import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.ext.gfm.tables.HtmlTablesExtension;
 import org.commonmark.ext.front.matter.YamlFrontMatterExtension;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.parser.Parser;
@@ -23,7 +23,7 @@ public class SpecIntegrationTest extends SpecTestCase {
             AutolinkExtension.create(),
             InsExtension.create(),
             StrikethroughExtension.create(),
-            TablesExtension.create(),
+            HtmlTablesExtension.create(),
             YamlFrontMatterExtension.create());
     private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.

--- a/commonmark-test-util/src/main/java/org/commonmark/test/RenderingTestCase.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/test/RenderingTestCase.java
@@ -6,12 +6,12 @@ public abstract class RenderingTestCase {
 
     protected abstract String render(String source);
 
-    protected void assertRendering(String source, String expectedHtml) {
-        String html = render(source);
+    protected void assertRendering(String source, String expectedResult) {
+        String renderedContent = render(source);
 
         // include source for better assertion errors
-        String expected = showTabs(expectedHtml + "\n\n" + source);
-        String actual = showTabs(html + "\n\n" + source);
+        String expected = showTabs(expectedResult + "\n\n" + source);
+        String actual = showTabs(renderedContent + "\n\n" + source);
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
This is a text content renderer that can be used to convert GFM tables to plain text output. we used this to have two converters for email output: one for HTML and one for plain text mail.